### PR TITLE
Adds ability to set where composer is located

### DIFF
--- a/src/PackageChecker.php
+++ b/src/PackageChecker.php
@@ -38,7 +38,7 @@ class PackageChecker
     private static function createProcess($command, array $flags = [])
     {
         $cmd = [
-            '/usr/local/bin/composer',
+            env('ENSEMBLE_COMPOSER_PATH', '/usr/local/bin/composer'),
             $command,
             '--format=json',
         ];


### PR DESCRIPTION
Since my app is on shared hosting, I use a phar file instead of actual composer. Ensemble shouldn't care where composer is located, it should pick a sensible default but allow the user to override it.